### PR TITLE
初始化时，大多数MCU需要先设置IO模式，后设置GPIO电平

### DIFF
--- a/beep.c
+++ b/beep.c
@@ -74,8 +74,8 @@ void beep_init(rt_base_t pin, rt_base_t reset_level)
 
     beep_set();
 #else /* PKG_BEEP_ACTIVE_BUZZER */
-    rt_pin_write(pin, reset_level);
     rt_pin_mode(pin, PIN_MODE_OUTPUT);
+    rt_pin_write(pin, reset_level);
 
     beep_data.pin = pin;
     beep_data.pin_reset_level = reset_level;


### PR DESCRIPTION
针对有源蜂鸣器，如果是低电平发声，IO应该初始化为高电平。如果先设置IO电平，后配置IO输出模式，导致初始化后输出低电平，蜂鸣器长鸣